### PR TITLE
Modify GitHub actions script for publishing documentation

### DIFF
--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -6,11 +6,6 @@ on:
     branches:
       - main
       - develop
-    paths:
-      - 'doc/**'
-      - 'docqueries/**'
-      - 'locale/**'
-
 
 jobs:
   release:

--- a/.github/workflows/publish-users-doc.yml
+++ b/.github/workflows/publish-users-doc.yml
@@ -2,6 +2,14 @@ name: Publish Users Documentation
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+      - develop
+    paths:
+      - 'doc/**'
+      - 'docqueries/**'
+      - 'locale/**'
 
 
 jobs:
@@ -27,6 +35,14 @@ jobs:
           echo "PGPORT=5432" >> $GITHUB_ENV
           echo "PGIS=3" >> $GITHUB_ENV
           echo "PROJECT_VERSION=${PROJECT_VERSION}" >> $GITHUB_ENV
+
+      - name: Extract branch name and commit hash
+        run: |
+          raw=$(git branch -r --contains ${{ github.ref }})
+          branch=${raw##*/}
+          echo "BRANCH=$branch" >> $GITHUB_ENV
+          git_hash=$(git rev-parse --short "$GITHUB_SHA")
+          echo "GIT_HASH=$git_hash" >> $GITHUB_ENV
 
       - name: Add PostgreSQL APT repository
         run: |
@@ -77,14 +93,17 @@ jobs:
 
       - name: Update Users Documentation
         run: |
+          if [[ "${{ env.BRANCH }}" == "main" ]]; then
+            FOLDER_NAME="main"
+          elif [[ "${{ env.BRANCH }}" == "develop" ]]; then
+            FOLDER_NAME="dev"
+          fi
           git checkout origin/gh-pages
           git checkout -b gh-pages
-          PROJECT_MAJOR_MINOR="v${PROJECT_VERSION%.*}"
-          rm -rf ${PROJECT_MAJOR_MINOR}
-          cp -r build/doc/html ${PROJECT_MAJOR_MINOR}
-          rm -rf ${PROJECT_MAJOR_MINOR}/es
-          git add ${PROJECT_MAJOR_MINOR}
-          git diff-index --quiet HEAD || git commit -m "Update users documentation for ${PROJECT_VERSION}"
+          rm -rf ${FOLDER_NAME}
+          cp -r build/doc/html ${FOLDER_NAME}
+          git add ${FOLDER_NAME}
+          git diff-index --quiet HEAD || git commit -m "Update users documentation for ${PROJECT_VERSION} (${{ env.BRANCH }}): commit ${{ env.GIT_HASH }}"
           git fetch origin
           git rebase origin/gh-pages
           git push origin gh-pages

--- a/.github/workflows/publish-users-doc.yml
+++ b/.github/workflows/publish-users-doc.yml
@@ -83,8 +83,7 @@ jobs:
         run: |
           cd build
           make doc
-          make -j 4
-          sudo make install
+          make doxy
 
       - name: Initialize mandatory git config
         run: |
@@ -107,6 +106,24 @@ jobs:
           git fetch origin
           git rebase origin/gh-pages
           git push origin gh-pages
+          git checkout @{-2}
+
+      - name: Update Developers Documentation
+        run: |
+          if [[ "${{ env.BRANCH }}" == "main" ]]; then
+            FOLDER_NAME="main"
+          elif [[ "${{ env.BRANCH }}" == "develop" ]]; then
+            FOLDER_NAME="dev"
+          fi
+          git checkout gh-pages
+          rm -rf doxy/${FOLDER_NAME}
+          cp -r build/doxygen/html doxy/${FOLDER_NAME}
+          git add doxy/${FOLDER_NAME}
+          git diff-index --quiet HEAD || git commit -m "Update developers documentation for ${PROJECT_VERSION} (${{ env.BRANCH }}): commit ${{ env.GIT_HASH }}"
+          git fetch origin
+          git rebase origin/gh-pages
+          git push origin gh-pages
+          git checkout @{-1}
 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,12 +99,11 @@ jobs:
         run: |
           git checkout origin/gh-pages
           git checkout -b gh-pages
-          PROJECT_MAJOR_MINOR="v${PROJECT_VERSION%.*}"
-          rm -rf ${PROJECT_MAJOR_MINOR}
-          cp -r build/doc/html ${PROJECT_MAJOR_MINOR}
-          rm -rf ${PROJECT_MAJOR_MINOR}/es
-          git add ${PROJECT_MAJOR_MINOR}
-          git diff-index --quiet HEAD || git commit -m "Update users documentation for ${PROJECT_VERSION}"
+          PROJECT_MAJOR="v${PROJECT_VERSION%%.*}"
+          rm -rf ${PROJECT_MAJOR}
+          cp -r build/doc/html ${PROJECT_MAJOR}
+          git add ${PROJECT_MAJOR}
+          git diff-index --quiet HEAD || git commit -m "Update users documentation for ${PROJECT_VERSION} (tag ${TAG_NAME})"
           git fetch origin
           git rebase origin/gh-pages
           git push origin gh-pages
@@ -117,7 +116,7 @@ jobs:
           rm -rf doxy/main
           cp -r build/doxygen/html doxy/main
           git add doxy/main
-          git diff-index --quiet HEAD || git commit -m "Update developers documentation for ${PROJECT_VERSION}"
+          git diff-index --quiet HEAD || git commit -m "Update developers documentation for ${PROJECT_VERSION} (tag ${TAG_NAME})"
           git fetch origin
           git rebase origin/gh-pages
           git push origin gh-pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,19 +109,6 @@ jobs:
           git push origin gh-pages
           git checkout @{-2}
 
-      - name: Update Developers Documentation
-        if: ${{ env.BRANCH == 'main' }}
-        run: |
-          git checkout gh-pages
-          rm -rf doxy/main
-          cp -r build/doxygen/html doxy/main
-          git add doxy/main
-          git diff-index --quiet HEAD || git commit -m "Update developers documentation for ${PROJECT_VERSION} (tag ${TAG_NAME})"
-          git fetch origin
-          git rebase origin/gh-pages
-          git push origin gh-pages
-          git checkout @{-1}
-
       - name: Download Assets
         run: |
           wget -c https://github.com/${{ github.repository }}/archive/${TAG_NAME}.zip


### PR DESCRIPTION
Changes proposed in this pull request:

Modified GitHub actions scripts for publishing documentation:
- Publishes users documentation on push to develop and main (in the dev or main directory).
- Publishes users documentation on tag push (but including only major version number: e.g. v0)
- Publishes developers documentation on push to develop and main (in doxy/dev or doxy/main directory).

Tested on my fork: [Commits on gh-pages branch](https://github.com/krashish8/vrprouting/commits/gh-pages) after pushing on main, develop, and creating v0.1.0 tag

@pgRouting/admins
