### PR TITLE
[vrp_pgr_pickDeliverEuclidean] fixing code for macos pgtap test

### DIFF
--- a/docqueries/version/doc-full_version.result
+++ b/docqueries/version/doc-full_version.result
@@ -4,9 +4,9 @@ SET client_min_messages TO NOTICE;
 SET
 -- q1
 SELECT version, library FROM vrp_full_version();
- version |     library
----------+------------------
- 0.2.0   | vrprouting-0.2.0
+  version  |     library
+-----------+------------------
+ 0.2.0-dev | vrprouting-0.2.0
 (1 row)
 
 -- q2

--- a/docqueries/version/doc-version.result
+++ b/docqueries/version/doc-version.result
@@ -6,7 +6,7 @@ SET
 SELECT vrp_version();
  vrp_version
 -------------
- 0.2.0
+ 0.2.0-dev
 (1 row)
 
 -- q2

--- a/src/common/get_check_data.c
+++ b/src/common/get_check_data.c
@@ -77,7 +77,7 @@ check_any_integer_type(Column_info_t info) {
         || info.type == INT8OID)) {
     ereport(ERROR,
         (errmsg_internal("Unexpected type in column '%s'.", info.name),
-         errhint("Found %lu", info.type)));
+         errhint("Expected ANY-INTEGER")));
   }
 }
 


### PR DESCRIPTION
The failing tests not only happened on macos, as the message of the throw were generated by a range check and was not the expected message.
the pick & deliver node identifiers are ignored when reading the data for the euclidean version, so I cleaned a little the code.
Also I updated the results of the query about the version.
which made me think that maybe we need it to be updated automatically when any PR is merged, no matter the branch.


@pgRouting/admins
