### PR TITLE
Add automatic locale update in GitHub actions

### DIFF
--- a/.github/workflows/locale-and-website.yml
+++ b/.github/workflows/locale-and-website.yml
@@ -1,4 +1,4 @@
-name: Publish Users Documentation
+name: Update Locale and Website
 
 on:
   workflow_dispatch:
@@ -9,7 +9,7 @@ on:
 
 jobs:
   release:
-    name: Publish Users Documentation
+    name: Update Locale and Website
     runs-on: ubuntu-latest
 
     strategy:
@@ -33,8 +33,7 @@ jobs:
 
       - name: Extract branch name and commit hash
         run: |
-          raw=$(git branch -r --contains ${{ github.ref }})
-          branch=${raw##*/}
+          branch=${GITHUB_REF#refs/heads/}
           echo "BRANCH=$branch" >> $GITHUB_ENV
           git_hash=$(git rev-parse --short "$GITHUB_SHA")
           echo "GIT_HASH=$git_hash" >> $GITHUB_ENV
@@ -65,6 +64,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install Sphinx
           pip install sphinx-bootstrap-theme
+          pip install sphinx-intl[transifex]
           pip list
 
       - name: Install VROOM dependencies
@@ -89,11 +89,14 @@ jobs:
           export PATH=/usr/lib/postgresql/${PGVER}/bin:$PATH
           mkdir build
           cd build
-          cmake -DPOSTGRESQL_VERSION=${PGVER} -DDOC_USE_BOOTSTRAP=ON -DWITH_DOC=ON -DBUILD_DOXY=ON -DCMAKE_BUILD_TYPE=Release -DES=ON -DVROOM_INSTALL_PATH=${VROOM_INSTALL_PATH} ..
+          cmake -DPOSTGRESQL_VERSION=${PGVER} -DDOC_USE_BOOTSTRAP=ON -DWITH_DOC=ON -DBUILD_DOXY=ON -DCMAKE_BUILD_TYPE=Release -DLOCALE=ON -DES=ON -DVROOM_INSTALL_PATH=${VROOM_INSTALL_PATH} ..
 
       - name: Build
         run: |
           cd build
+          if [[ "${{ env.BRANCH }}" == "develop" ]]; then
+            make locale
+          fi
           make doc
           make doxy
 
@@ -101,6 +104,23 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Update locale
+        if: github.ref == 'refs/heads/develop'
+        run: |
+          # List all the files that needs to be committed in build/doc/locale_changes.txt
+          awk '/^Update|^Create/{print $2}' build/doc/locale_changes.txt > tmp && mv tmp build/doc/locale_changes.txt        # .po files
+          cat build/doc/locale_changes.txt | perl -pe 's/(.*)en\/LC_MESSAGES(.*)/$1pot$2t/' >> build/doc/locale_changes.txt  # .pot files
+          cat build/doc/locale_changes.txt
+          # Remove obsolete entries #~ from .po files
+          tools/transifex/remove_obsolete_entries.sh
+          # Add the files, commit and push
+          for line in `cat build/doc/locale_changes.txt`; do git add "$line"; done
+          git diff --staged --quiet || git commit -m "Update locale: commit ${{ env.GIT_HASH }}"
+          git fetch origin
+          git reset --hard  # Remove the unstaged changes before rebasing
+          git rebase origin/develop
+          git push origin develop
 
       - name: Update Users Documentation
         run: |

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -238,7 +238,7 @@ if (LOCALE)
         "${PGR_DOCUMENTATION_SOURCE_DIR}"
         "${CMAKE_SOURCE_DIR}/locale/pot"
 
-        COMMAND sphinx-intl update -d ${CMAKE_SOURCE_DIR}/locale -l en
+        COMMAND sphinx-intl update -d ${CMAKE_SOURCE_DIR}/locale -l en > locale_changes.txt
     #COMMAND sphinx-intl update -p ${CMAKE_SOURCE_DIR}/locale/pot -d ${CMAKE_SOURCE_DIR}/locale --language=${SPHINXINTL_LANGUAGE}
     #COMMAND sphinx-intl update-txconfig-resources --locale-dir ${CMAKE_SOURCE_DIR}/locale --pot-dir ${CMAKE_SOURCE_DIR}/locale/pot --transifex-project-name pgrouting
 
@@ -246,7 +246,6 @@ if (LOCALE)
     COMMENT "Generating POT files ..."
     SOURCES ${PROJECT_DOC_FILES}
     )
-    return()
 endif()
 
 

--- a/tools/transifex/remove_obsolete_entries.sh
+++ b/tools/transifex/remove_obsolete_entries.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# ------------------------------------------------------------------------------
+# vrpRouting Scripts
+# Copyright(c) vrpRouting Contributors
+#
+# Remove all the obsolete entries, i.e. lines starting with #~ from .po files
+# ------------------------------------------------------------------------------
+
+# For all the chapter files
+for file in locale/en/LC_MESSAGES/*.po; do
+    if grep -q '#~' "$file"; then
+        perl -pi -0777 -e 's/#~.*//s' "$file"
+        git add "$file"
+    fi
+done
+


### PR DESCRIPTION
Changes proposed in this pull request:
- Add code to automatically update locale on `develop`, when PR is merged to `develop`.
- Add script to remove the obsolete entries, i.e. lines starting with `#~` from .po files
- Tested on my fork: [develop branch](https://github.com/krashish8/vrprouting/commits/develop), [Actions Workflow](https://github.com/krashish8/vrprouting/actions/workflows/locale-and-website.yml)

@pgRouting/admins
